### PR TITLE
Replace RuntimeException handling with IllegalArgumentException

### DIFF
--- a/src/main/java/tech/makers/aceplay/playlist/PlaylistsController.java
+++ b/src/main/java/tech/makers/aceplay/playlist/PlaylistsController.java
@@ -9,6 +9,10 @@ import org.springframework.web.server.ResponseStatusException;
 import tech.makers.aceplay.track.Track;
 import tech.makers.aceplay.track.TrackRepository;
 
+import javax.xml.bind.ValidationException;
+import java.util.Objects;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 // https://www.youtube.com/watch?v=vreyOZxdb5Y&t=0s
@@ -24,16 +28,15 @@ public class PlaylistsController {
   }
 
   // Need to refactor this into new class
-  @ExceptionHandler(RuntimeException.class)
+  @ExceptionHandler(IllegalArgumentException.class)
   public ResponseEntity<String> handleError(RuntimeException ex) {
     return new ResponseEntity<>(ex.getMessage(), new HttpHeaders(), HttpStatus.BAD_REQUEST);
   }
 
   @PostMapping("/api/playlists")
   public Playlist create(@RequestBody Playlist playlist) {
-    if (playlist.getName() == "")
-      throw new RuntimeException("Playlist name is empty.");
-
+    if (playlist.getName().equals(""))
+      throw new IllegalArgumentException("Playlist name cannot be empty");
     return playlistRepository.save(playlist);
   }
 

--- a/src/test/java/tech/makers/aceplay/playlist/PlaylistsControllerIntegrationTest.java
+++ b/src/test/java/tech/makers/aceplay/playlist/PlaylistsControllerIntegrationTest.java
@@ -11,9 +11,12 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.web.server.ResponseStatusException;
 import tech.makers.aceplay.track.Track;
 import tech.makers.aceplay.track.TrackRepository;
 
+import javax.xml.bind.ValidationException;
+import java.util.Objects;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.hasSize;
@@ -167,8 +170,8 @@ class PlaylistsControllerIntegrationTest {
                       .contentType(MediaType.APPLICATION_JSON)
                       .content("{\"name\": \"\"}"))
               .andExpect(status().isBadRequest())
-              .andExpect(result -> assertTrue(result.getResolvedException() instanceof Exception))
-              .andExpect(result -> assertEquals("Playlist name is empty.", result.getResolvedException().getMessage()));
+              .andExpect(result -> assertTrue(result.getResolvedException() instanceof IllegalArgumentException))
+              .andExpect(result -> assertEquals("Playlist name cannot be empty", Objects.requireNonNull(result.getResolvedException()).getMessage()));
 
       assertNull(repository.findFirstByOrderByIdAsc());
     }


### PR DESCRIPTION
## Before you start

1. Have you run `git pull origin main` on your branch to bring in the latest changes?
2. Is this code consistent with the rest of the codebase?
3. Consider if this will impact any other features people are working on currently.

## What do these code changes do?

Fix exceptionHandler as it was catching all runtimeExceptions and causing tests expecting other exceptions to fail.
Playlist postMapping now throws IllegalArgumentException which is caught and returned

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests (if applicable).
- [x] I will demo this feature to the rest of the group.
- [x] I will resolve merge conflicts on GitHub.
